### PR TITLE
Output the "Reading profile %s" message to stderr

### DIFF
--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -356,7 +356,7 @@ void profile_read(const char *fname) {
 		exit(1);
 	}
 
-	printf("Reading profile %s\n", fname);
+	fprintf(stderr, "Reading profile %s\n", fname);
 
 	// read the file line by line
 	char buf[MAX_READ + 1];


### PR DESCRIPTION
If firejail is used in a pipeline, these messages would be included with the output the isolated process is producing, adding noise to the result.

This patch simply outputs the exact same message to stderr.
